### PR TITLE
Refactor: implement prisma using singleton pattern

### DIFF
--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -1,3 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 
+
 export const prisma = new PrismaClient();
+
+export type PrismaClientType = typeof prisma;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,15 +1,10 @@
 import { Request, Response } from 'express';
 import { verifyToken } from '../utils/auth';
 import { UserService } from '../modules/user/user.service';
-import { PrismaClient } from '@prisma/client';
+import { prisma} from '../lib/prisma';
+import { GraphQLContext } from '../types';
 
 const userService = new UserService();
-const prisma = new PrismaClient();
-
-export interface GraphQLContext {
-  user?: any;
-  prisma: PrismaClient;
-}
 
 export const createGraphQLContext = async ({ req, res }: { req: Request; res: Response }): Promise<GraphQLContext> => {
   try {
@@ -23,7 +18,7 @@ export const createGraphQLContext = async ({ req, res }: { req: Request; res: Re
     const token = authHeader.split(' ')[1];
     const decoded = verifyToken(token);
     
-    const user = await userService.getUserByIdWithoutPassword(decoded.userId);
+    const user = await userService.getUserByIdWithoutPassword(decoded.userId, prisma);
 
     return { user, prisma };
   } catch (error) {

--- a/backend/src/modules/task/task.service.ts
+++ b/backend/src/modules/task/task.service.ts
@@ -1,20 +1,13 @@
-//import { TaskStatus as PrismaTaskStatus } from '@prisma/client'; 
 import { CreateTaskInput, UpdateTaskInput } from './task.schema';
+import { Prisma } from '@prisma/client';
 import { AppError } from '../../lib/AppErrors';
 import { handlePrismaError } from '../../lib/PrismaErrorHelper';
-import { prisma } from '../../lib/prisma';
-
-
-
-
-
-interface TaskFilters {
-  status?: string;
-  sortBy?: 'CREATED_ASC' | 'CREATED_DESC' | 'DUE_ASC' | 'DUE_DESC' | 'NAME_ASC' | 'NAME_DESC';
-}
+import { TaskFilters } from '../../types';
+import { PrismaClientType } from '../../lib/prisma';
 
 export class TaskService {
-  async verifyTaskOwnership(taskId: number, userId: number) {
+
+  async verifyTaskOwnership(taskId: number, userId: number, prisma:PrismaClientType) {
     const task = await prisma.task.findUnique({
       where: { id: taskId },
       select: { userId: true }
@@ -33,7 +26,7 @@ export class TaskService {
 
   
   //create
-  async createTask(data: CreateTaskInput, userId: number) {
+  async createTask(data: CreateTaskInput, userId: number, prisma:PrismaClientType) {
     try {
       const existingTask = await prisma.task.findFirst({
         where: {
@@ -59,9 +52,9 @@ export class TaskService {
 
   
 //Read
- async getTaskById(id: number, userId: number) {
+ async getTaskById(id: number, userId: number, prisma:PrismaClientType) {
     try {
-      await this.verifyTaskOwnership(id, userId);
+      await this.verifyTaskOwnership(id, userId, prisma);
       
       const task = await prisma.task.findUnique({ 
         where: { id }
@@ -77,12 +70,12 @@ export class TaskService {
   }
 
 
-  async getTasksByUserId(userId: number, filters : TaskFilters = {}) {
+  async getTasksByUserId(userId: number, filters : TaskFilters = {}, prisma:PrismaClientType) {
   try {
-    const where: any = { userId };
+    const where: Prisma.TaskWhereInput= { userId };
 
     // Default sorting
-    let orderBy: any = { createdAt: 'desc' };
+    let orderBy: Prisma.TaskOrderByWithRelationInput = { createdAt: 'desc' };
 
     if (filters.status) {
       where.status = filters.status;
@@ -121,9 +114,9 @@ export class TaskService {
 }
 
 //Update
-   async updateTask(id: number, data: UpdateTaskInput, userId: number) {
+   async updateTask(id: number, data: UpdateTaskInput, userId: number, prisma: PrismaClientType) {
     try {
-      await this.verifyTaskOwnership(id, userId);
+      await this.verifyTaskOwnership(id, userId, prisma);
 
       return await prisma.task.update({
         where: { id },
@@ -139,9 +132,9 @@ export class TaskService {
 
 
 //delete
-  async deleteTask(id: number, userId: number) {
+  async deleteTask(id: number, userId: number, prisma:PrismaClientType) {
     try {
-      await this.verifyTaskOwnership(id, userId);
+      await this.verifyTaskOwnership(id, userId, prisma);
 
       await prisma.task.delete({ where: { id } });
       return true;

--- a/backend/src/modules/user/user.resolver.ts
+++ b/backend/src/modules/user/user.resolver.ts
@@ -2,7 +2,7 @@ import { UserService } from './user.service';
 import { CreateUserSchema, UpdateUserInputSchema, LoginSchema, CreateUserInput, UpdateUserInput, LoginInput, } from './user.schema';
 import { UserWithTasks } from '../../types';
 import { validation } from '../../lib/validation';
-import { GraphQLContext } from '../../middleware/auth';
+import { GraphQLContext } from '../../types';
 
 const userService = new UserService();
 
@@ -35,7 +35,7 @@ export const userResolvers = {
         throw new Error('You can only view your own profile.');
       }
       
-      return userService.getUserById(userId);
+      return userService.getUserById(userId, context.prisma);
     },
 
     userByEmail: async (_: unknown, { email }: { email: string }, context: GraphQLContext) => {
@@ -50,19 +50,19 @@ export const userResolvers = {
         throw new Error('You can only view your own profile.');
       }
       
-      return userService.getUserByEmail(userEmail);
+      return userService.getUserByEmail(userEmail,context.prisma);
     },
   },
 
    Mutation: {
-    register: async (_: unknown, { input }: { input: CreateUserInput }) => {
+    register: async (_: unknown, { input }: { input: CreateUserInput }, context: GraphQLContext) => {
       const validatedData = CreateUserSchema.parse(input);
-      return userService.createUser(validatedData);
+      return userService.createUser(validatedData, context.prisma);
     },
 
-    login: async (_: unknown, { input }: { input: LoginInput }) => {
+    login: async (_: unknown, { input }: { input: LoginInput }, context: GraphQLContext) => {
       const validatedData = LoginSchema.parse(input);
-      return userService.login(validatedData);
+      return userService.login(validatedData, context.prisma);
     },
 
     updateUser: async (_: unknown, { id, input }: { id: string; input: UpdateUserInput }, context: GraphQLContext) => {
@@ -78,7 +78,7 @@ export const userResolvers = {
         throw new Error('You can only update your own account.');
       }
       
-      return userService.updateUser(userId, validatedData);
+      return userService.updateUser(userId, validatedData, context.prisma);
     },
 
     deleteUser: async (_: unknown, { id }: { id: string }, context: GraphQLContext) => {
@@ -92,7 +92,7 @@ export const userResolvers = {
       if (context.user.id !== userId) {
         throw new Error('You can only delete your own account.');
       }
-      return userService.deleteUser(userId);
+      return userService.deleteUser(userId,  context.prisma);
     },
   },
 
@@ -103,7 +103,7 @@ export const userResolvers = {
       if (user.tasks) return user.tasks;
       
       // Otherwise fetch them
-      return userService.getUserTasks(user.id);
+      return userService.getUserTasks(user.id, context.prisma);
     },
   },
 };

--- a/backend/src/modules/user/user.schema.ts
+++ b/backend/src/modules/user/user.schema.ts
@@ -47,17 +47,6 @@ export const LoginSchema = z.object({
   password: PasswordSchema
 });
 
-// Auth Payload Schema (for login/register responses)
-export const AuthPayloadSchema = z.object({
-  token: z.string(),
-  user: z.object({
-    id: z.number(),
-    email: z.string(),
-    name: z.string().nullable(),
-    createdAt: z.date(),
-    updatedAt: z.date()
-  })
-});
 
 // Validation for user ID
 export const UserIdSchema = z.object({
@@ -72,16 +61,5 @@ export const UserIdSchema = z.object({
 export type CreateUserInput = z.infer<typeof CreateUserSchema>;
 export type UpdateUserInput = z.infer<typeof UpdateUserInputSchema>;
 export type LoginInput = z.infer<typeof LoginSchema>;
-export type AuthPayload = z.infer<typeof AuthPayloadSchema>;
 export type UserIdInput = z.infer<typeof UserIdSchema>;
 
-
-export const UserWithoutPasswordSchema = z.object({
-  id: z.number(),
-  email: z.string(),
-  name: z.string().nullable(),
-  createdAt: z.date(),
-  updatedAt: z.date()
-});
-
-export type UserWithoutPassword = z.infer<typeof UserWithoutPasswordSchema>;

--- a/backend/src/modules/user/user.service.ts
+++ b/backend/src/modules/user/user.service.ts
@@ -1,14 +1,16 @@
-import { UpdateUserInputSchema, CreateUserInput, UpdateUserInput, LoginInput, AuthPayload } from './user.schema';
+import { UpdateUserInputSchema, CreateUserInput, UpdateUserInput, LoginInput} from './user.schema';
 import { AppError } from '../../lib/AppErrors';
 import { handlePrismaError } from '../../lib/PrismaErrorHelper';
 import { generateToken, hashPassword, comparePassword } from '../../utils/auth';
-import { prisma } from '../../lib/prisma';
+import {PrismaClientType } from '../../lib/prisma';
+import { AuthPayload } from '../../types';
+
 
 
 export class UserService {
 
   // Create
-  async createUser(data: CreateUserInput) {
+  async createUser(data: CreateUserInput, prisma: PrismaClientType ) {
 
     const existingUser = await prisma.user.findUnique({
       where: { email: data.email }
@@ -49,7 +51,7 @@ export class UserService {
 
 
   //login
-  async login(data: LoginInput): Promise<AuthPayload> {
+  async login(data: LoginInput , prisma: PrismaClientType ): Promise<AuthPayload> {
   
     try {
       const user = await prisma.user.findUnique({
@@ -86,7 +88,7 @@ export class UserService {
 
   // Read
   // Get user by ID without password (for authentication context)
-  async getUserByIdWithoutPassword(id: number) {
+  async getUserByIdWithoutPassword(id: number, prisma: PrismaClientType ) {
     try {
       const user = await prisma.user.findUnique({
         where: { id },
@@ -111,7 +113,7 @@ export class UserService {
   }
 
   //eventually change for admin only
-  async getUsers() {
+  async getUsers(prisma: PrismaClientType ) {
     try {
       return await prisma.user.findMany({
         select: {
@@ -128,7 +130,7 @@ export class UserService {
     }
   }
 
-  async getUserById(id: number) {
+  async getUserById(id: number, prisma: PrismaClientType ) {
     try {
       const user = await prisma.user.findUnique({
         where: { id },
@@ -147,7 +149,7 @@ export class UserService {
     }
   }
 
-  async getUserByEmail(email: string) {
+  async getUserByEmail(email: string, prisma: PrismaClientType ) {
     try {
       const user = await prisma.user.findUnique({
         where: { email },
@@ -166,7 +168,7 @@ export class UserService {
     }
   }
 
-  async getUserTasks(userId: number) {
+  async getUserTasks(userId: number, prisma: PrismaClientType ) {
     try {
       return await prisma.task.findMany({
         where: { userId },
@@ -179,7 +181,7 @@ export class UserService {
 
 
   // Update
-  async updateUser(id: number, data: UpdateUserInput) {
+  async updateUser(id: number, data: UpdateUserInput, prisma: PrismaClientType ) {
     // Remove the currentUserId parameter since we're already checking in resolvers
     const validatedData = UpdateUserInputSchema.parse(data);
     
@@ -210,7 +212,7 @@ export class UserService {
 
 
   // Delete
-  async deleteUser(id: number) {
+  async deleteUser(id: number, prisma: PrismaClientType) {
     try {
         await prisma.user.delete({ where: { id } });
         return true;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1,4 +1,6 @@
-import { User, Task } from '@prisma/client';
+import { User, Task, TaskStatus } from '@prisma/client';
+import { PrismaClientType } from './lib/prisma';
+
 
 export type UserWithTasks = User & {
   tasks?: Task[];
@@ -7,3 +9,32 @@ export type UserWithTasks = User & {
 export type TaskWithUser = Task & {
   user: User;
 };
+
+export type UserWithoutPassword = {
+  id: number;
+  email: string;
+  name: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+
+export interface GraphQLContext {
+  user?: UserWithoutPassword;
+  prisma: PrismaClientType;
+}
+
+export type AuthPayload = {
+  token: string;
+  user: UserWithoutPassword;
+};
+
+//fix soon
+ export interface JWTPayload {
+  userId: number; 
+}
+
+export interface TaskFilters {
+  status?: TaskStatus;
+  sortBy?: 'CREATED_ASC' | 'CREATED_DESC' | 'DUE_ASC' | 'DUE_DESC' | 'NAME_ASC' | 'NAME_DESC';
+}

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -1,11 +1,10 @@
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 import { env } from '../config/env';
+import { JWTPayload } from '../types';
 
 const JWT_EXPIRES_IN = '7d';
-export interface JWTPayload {
-  userId: number;
-}
+
 
 export const generateToken = (userId: number): string => {
     if (!env.jwtSecret) {


### PR DESCRIPTION
Refactor: implement prisma using singleton pattern
- remove multiple Prisma client instances
- refactor services and resolvers to use prisma instance via GraphQLcontext
- centralized types in types.ts and remove redundant Zod Validation types
- Improve type safety for function parameters 
